### PR TITLE
Adding featuretools and nlp_primitives to evalml-core and evalml conda packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1c4c440e9370f49ad21100908285a23e7c38fbc872feba34c0e6c47c39db8f76
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: evalml-core
@@ -25,7 +25,7 @@ outputs:
       run:
         - numpy >=1.16.4
         - pandas >=0.25.0
-        - scipy >=1.2.1,<1.5.0
+        - scipy >=1.2.1
         - scikit-learn >=0.21.3,!=0.22,<0.23.0
         - scikit-optimize
         - tqdm >=4.33.0
@@ -45,12 +45,14 @@ outputs:
         - nbval ==0.9.3
         - python-graphviz >=0.8.4
         - category_encoders >=2.0.0
+        - featuretools
+        - nlp-primitives >=1.0.0
       source_files:
         - evalml/*
         - requirements.txt
         - core-requirements.txt
       commands:
-        - pytest evalml/tests --has-minimal-dependencies --deselect evalml/tests/component_tests/test_utils.py::test_all_components
+        - pytest evalml/tests --has-minimal-dependencies
 
   - name: evalml
     build:
@@ -71,12 +73,14 @@ outputs:
         - nbval ==0.9.3
         - python-graphviz >=0.8.4
         - category_encoders >=2.0.0
+        - featuretools
+        - nlp-primitives >=1.0.0
       source_files:
         - evalml/*
         - requirements.txt
         - core-requirements.txt
       commands:
-        - pytest evalml/tests --deselect evalml/tests/component_tests/test_utils.py::test_all_components
+        - pytest evalml/tests
 
 about:
   doc_url: https://evalml.featurelabs.com/en/stable/


### PR DESCRIPTION
Adds featuretools and nlp-primitives (doesn't include tensorflow) as test dependencies to evalml and evalml-core conda packages.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
