### PR TITLE
Modify feedstock so pyyaml can parse

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bb555d790675535345d733d1b10e2f2dc3b1decfd92ad42583a316e5fa5f012f
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: evalml-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: evalml-core
-  version: {{ version }}
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/e/evalml/evalml-{{ version }}.tar.gz
@@ -59,7 +59,7 @@ outputs:
       noarch: python
     requirements:
       run:
-        - {{ pin_subpackage('evalml-core', max_pin="x.x.x.x") }}
+        - '{{ pin_subpackage("evalml-core", max_pin="x.x.x.x") }}'
         - plotly >=4.2.1
         - ipywidgets >=7.5
         - py-xgboost >=0.82


### PR DESCRIPTION
Add quotes around the template vars so that yaml loaders will read them as scalar values.  This is should not effect existing jinja2 functionality.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Required to enable conda packages to be built as part of the CI process