### PR TITLE
Add Conda Flag to Tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 67312e04a62463ea7897ea91b624ed1819c03d7c7bcbf327c7bcca38ba64e0e5
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: evalml-core
@@ -87,7 +87,7 @@ outputs:
         - requirements.txt
         - core-requirements.txt
       commands:
-        - pytest evalml/tests -n 8
+        - pytest evalml/tests -n 8 --is-using-conda
 
 about:
   doc_url: https://evalml.featurelabs.com/


### PR DESCRIPTION
Adds ` --is-using-conda` flag for the non-minimal dependencies test so that the tests execute differently based on `pmdarima` not being available in the feedstock.
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
